### PR TITLE
Add support for expiration_policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ module "pubsub" {
       ack_deadline_seconds = 20 // optional
       push_endpoint        = "https://example.com" // required
       x-goog-version       = "v1beta1" // optional
+      expiration_policy    = "1209600s" // optional
     }
   ]
   pull_subscriptions = [

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -38,6 +38,7 @@ module "pubsub" {
       push_endpoint        = "https://${var.project_id}.appspot.com/"
       x-goog-version       = "v1beta1"
       ack_deadline_seconds = 20
+      expiration_policy    = "1209600s" // two weeks
     },
   ]
 

--- a/main.tf
+++ b/main.tf
@@ -47,6 +47,13 @@ resource "google_pubsub_subscription" "push_subscriptions" {
     "message_retention_duration",
     null,
   )
+  dynamic "expiration_policy" {
+    // check if the 'expiration_policy' key exists, if yes, return a list containing it.
+    for_each = contains(keys(var.push_subscriptions[count.index]), "expiration_policy") ? [var.push_subscriptions[count.index].expiration_policy] : []
+    content {
+      ttl = expiration_policy.value
+    }
+  }
 
   push_config {
     push_endpoint = var.push_subscriptions[count.index]["push_endpoint"]
@@ -76,6 +83,13 @@ resource "google_pubsub_subscription" "pull_subscriptions" {
     "message_retention_duration",
     null,
   )
+  dynamic "expiration_policy" {
+    // check if the 'expiration_policy' key exists, if yes, return a list containing it.
+    for_each = contains(keys(var.pull_subscriptions[count.index]), "expiration_policy") ? [var.pull_subscriptions[count.index].expiration_policy] : []
+    content {
+      ttl = expiration_policy.value
+    }
+  }
 
   depends_on = [google_pubsub_topic.topic]
 }


### PR DESCRIPTION
The block `expiration_policy` is supported by the
google_pubsub_subscription resource, but has not been exposed in this
module yet. This commit adds support for setting that expiration policy
as an attribute, that then gets rendered by a 'dynamic block'.

Signed-off-by: Ramon Rüttimann <me@ramonr.ch>